### PR TITLE
By default set client idle timeout

### DIFF
--- a/zio-http/src/main/scala/zio/http/ZClient.scala
+++ b/zio-http/src/main/scala/zio/http/ZClient.scala
@@ -608,7 +608,7 @@ object ZClient {
       localAddress = None,
       addUserAgentHeader = true,
       webSocketConfig = WebSocketConfig.default,
-      idleTimeout = None,
+      idleTimeout = Some(50.seconds),
       connectionTimeout = None,
     )
   }


### PR DESCRIPTION
Having no idle timeout by default is not the right choice. Most modern environments (e.g. every cloud, every proxy) forget about idle connections fairly quickly. For example, I have worked with proxies that forgot about connections after an idle time of as low as 90 seconds.

In this change we set the default idle time to 50 seconds.